### PR TITLE
Revert "Bump actions/checkout from 3 to 4 (#12)"

### DIFF
--- a/.github/workflows/interpolation.yml
+++ b/.github/workflows/interpolation.yml
@@ -17,7 +17,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Check out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Show how single quotes suppress escaping
         run: printf '%s\n' '%s\n'  # Doubling '%s\n', to see it.


### PR DESCRIPTION
Temporarily put actions/checkout back to major version 3 for Dependabot testing.

This reverts commit b5cced2c9f87553d749740f499d8abdd976970ab.