### PR TITLE
Add script and workflow to test code-scanning-rubocop

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,56 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# pulled from repo
+name: "Rubocop"
+
+on: [push, pull_request]
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+
+    - name: Create Gemfile if absent
+      run: |
+        if ! test -e Gemfile; then
+          bundle init
+          touch .new_gemfile
+        fi
+
+    # This step is not necessary if you add the gem to your Gemfile
+    - name: Install Code Scanning integration
+      run: bundle add code-scanning-rubocop --version 0.3.0 --skip-install
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Make Gemfile use single quotes if new
+      run: |
+        if test -e .new_gemfile; then
+          q="'"
+          qq='"'
+          sed -i "s/$qq/$q/g" Gemfile
+        fi
+
+    # Modified to print results in log and fail if there are any errors/warnings.
+    - name: Rubocop run
+      run: |
+        bundle exec rubocop --require code_scanning --format progress --format CodeScanning::SarifFormatter -o rubocop.sarif
+
+    - name: Upload Sarif output
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: rubocop.sarif

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -51,6 +51,7 @@ jobs:
         bundle exec rubocop --require code_scanning --format progress --format CodeScanning::SarifFormatter -o rubocop.sarif
 
     - name: Upload Sarif output
+      if: success() || failure()
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: rubocop.sarif

--- a/hello.rb
+++ b/hello.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-# frozen_string_literal: true
 
 $VERBOSE = true
 

--- a/hello.rb
+++ b/hello.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$VERBOSE = true
+
+puts 'This is an example Ruby script for testing code-scanning-rubocop.'

--- a/hello.rb
+++ b/hello.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $VERBOSE = true
 


### PR DESCRIPTION
The `rubocop.yml` workflow here is the one I added in https://github.com/EliahKagan/sieve-ksh/pull/4, including modifications made as part of that PR, but excluding later changes.

The idea here is to produce an error in the `upload-sarif` step when the workflow is run on a Dependabot branch with the push trigger (due to a Dependabot PR being opened, or changes made to it). Then a more robust fix than the changes I made to the workflow by the commits I added to https://github.com/EliahKagan/sieve-ksh/pull/5 can be found.