### PR TITLE
Try out readthedocs/actions/preview

### DIFF
--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -1,0 +1,15 @@
+name: readthedocs/actions
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: readthedocs/actions/preview@v1
+      with:
+        project-slug: "bb40a0fa-a7e4-43c0-b70a-416ad8380a13"  # fake, for testing


### PR DESCRIPTION
This repo doesn't actually have anything on Read the Docs, so I used the fake slug "bb40a0fa-a7e4-43c0-b70a-416ad8380a13".

<!-- readthedocs-preview bb40a0fa-a7e4-43c0-b70a-416ad8380a13 start -->
----
📚 Documentation preview 📚: https://bb40a0fa-a7e4-43c0-b70a-416ad8380a13--18.org.readthedocs.build/en/18/

<!-- readthedocs-preview bb40a0fa-a7e4-43c0-b70a-416ad8380a13 end -->