### PR TITLE
Use simpler fake slug

### DIFF
--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: readthedocs/actions/preview@v1
       with:
-        project-slug: "bb40a0fa-a7e4-43c0-b70a-416ad8380a13"  # fake, for testing
+        project-slug: "fake-slug"  # Fake slug for testing.


### PR DESCRIPTION
I think real slugs don't have hyphens, so this shouldn't match a real one.

<!-- readthedocs-preview bb40a0fa-a7e4-43c0-b70a-416ad8380a13 start -->
----
📚 Documentation preview 📚: https://bb40a0fa-a7e4-43c0-b70a-416ad8380a13--22.org.readthedocs.build/en/22/

<!-- readthedocs-preview bb40a0fa-a7e4-43c0-b70a-416ad8380a13 end -->