### PR TITLE
Try to force Node 20

### DIFF
--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: "true"
+
 jobs:
   documentation-links:
     name: Add link in PR


### PR DESCRIPTION
For readthedocs/actions/preview, the latest version of which is still a Node 16 action.

For context:
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

<!-- readthedocs-preview fake-slug start -->
----
📚 [Documentation preview](https://fake-slug--27.org.readthedocs.build/en/27/) (see [all builds](https://readthedocs.org/projects/fake-slug/builds/)) 📚 

<!-- readthedocs-preview fake-slug end -->