### PR TITLE
More OS choices for the reverse shell workflow

### DIFF
--- a/.github/workflows/reverse-shell.yml
+++ b/.github/workflows/reverse-shell.yml
@@ -6,19 +6,21 @@ on:
       os:
         description: Operating System
         required: true
-        default: ubuntu
+        default: ubuntu-latest
         type: choice
         options:
-        - ubuntu
-        - macos
-        - windows
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+        - macos-latest
+        - windows-latest
+        - windows-11-arm
 
 permissions:
   contents: read
 
 jobs:
   reverse-shell:
-    runs-on: ${{ inputs.os }}-latest
+    runs-on: ${{ inputs.os }}
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
This adds ARM Ubuntu and ARM Windows.

<!-- readthedocs-preview fake-slug start -->
----
📚 [Documentation preview](https://fake-slug--36.org.readthedocs.build/en/36/) (see [all builds](https://readthedocs.org/projects/fake-slug/builds/)) 📚 

<!-- readthedocs-preview fake-slug end -->