### PR TITLE
Add ARM jobs to `bash-env` workflow

### DIFF
--- a/.github/workflows/bash-env.yml
+++ b/.github/workflows/bash-env.yml
@@ -6,7 +6,12 @@ jobs:
   examine-bash-env:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os:
+        - ubuntu-latest
+        - ubuntu-24.04-arm
+        - macos-latest
+        - windows-latest
+        - windows-11-arm
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I expect no problems on `ubuntu-24.04-arm`, but I am not sure if this will currently work on the newly available `windows-11-arm`.

<!-- readthedocs-preview fake-slug start -->
----
📚 [Documentation preview](https://fake-slug--37.org.readthedocs.build/en/37/) (see [all builds](https://readthedocs.org/projects/fake-slug/builds/)) 📚 

<!-- readthedocs-preview fake-slug end -->