### PR TITLE
Add workflow to check for `curl` on the runner

### DIFF
--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -19,8 +19,12 @@ jobs:
     steps:
     - name: Check from bash
       shell: bash
-      run: type curl
+      run: |
+        type curl
+        curl --version
 
     - name: Check from PowerShell
       shell: pwsh
-      run: gcm curl
+      run: |
+        gcm curl
+        curl --version


### PR DESCRIPTION
In both `bash` and `pwsh`, on multiple systems.

<!-- readthedocs-preview fake-slug start -->
----
📚 [Documentation preview](https://fake-slug--38.org.readthedocs.build/en/38/) (see [all builds](https://readthedocs.org/projects/fake-slug/builds/)) 📚 

<!-- readthedocs-preview fake-slug end -->